### PR TITLE
Limit viewing of results to logged-in users

### DIFF
--- a/conference_keeper.rb
+++ b/conference_keeper.rb
@@ -98,6 +98,12 @@ post "/election/:id" do
 end
 
 get "/election/results/:id" do
+  unless person = Person.find_by_username(session[:username])      
+    @page_title = "Not signed in"
+    @message = "You are not signed in properly!"
+    return haml :"election/error", {:layout => :"common/layout"}  
+  end
+
   unless params[:id]
     redirect_to :action=>'list_elections'
     return    


### PR DESCRIPTION
Based on changes to the keynote speaker selection process code Code4Lib 2014, discussed with the Keynote selection committee, 2014 organizing committee, and presented to the code4libcon list:

We would like to require users to log in before viewing keynote voting results. This is an attempt to maintain the community-facing transparency of the selection process (through the free creation of accounts) without subjecting potential speakers to an easily discoverable public vote.This pull request restricts the viewing of all election results to logged-in users. This is the most straightforward approach, but if we'd rather restrict only keynote results, I can work out something for that instead.
